### PR TITLE
Docs: Fix 'helloworld' typo in README.md (test external PR flow)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,6 @@ bazel-bin/src/java/com/google/devtools/mobileharness/infra/lab/lab_server_oss_de
 
 ## Run an example
 
-To run an example helloworld test using these jars built, you may reference the
+To run an example hello world test using these jars built, you may reference the
 [OlcServerIntegrationTest](https://github.com/google/device-infra/blob/f96966f3ba4d8bf614d64c08d06bb200d50cd8d5/src/javatests/com/google/devtools/mobileharness/infra/client/longrunningservice/OlcServerIntegrationTest.java)
 file and follow how these binaries are started.


### PR DESCRIPTION
This is a lightweight test PR to verify the external contribution and Copybara synchronization flow.

### Changes
- Fix typo `helloworld` -> `hello world` in README.md.